### PR TITLE
Replaced dedicated deployment scripts path to utilities repo' common scripts

### DIFF
--- a/yugabyte_deployment.json
+++ b/yugabyte_deployment.json
@@ -19,7 +19,8 @@
     },
     "variables": {
        "count" : 3,
-       "vmSize" : "Standard_D2s_v3"
+       "vmSize" : "Standard_D2s_v3",
+       "singleQuote" : "'"
     },
     "resources": [
         {
@@ -213,14 +214,14 @@
                       "autoUpgradeMinorVersion": true,
                       "settings": {
                         "fileUris": [
-                          "https://raw.githubusercontent.com/YugaByte/utilities/master/azure_scripts/install_software.sh",
+                          "https://raw.githubusercontent.com/YugaByte/utilities/master/common_scripts/install_software.sh",
                           "https://raw.githubusercontent.com/YugaByte/utilities/master/scripts/start_master.sh",
                           "https://raw.githubusercontent.com/YugaByte/utilities/master/scripts/start_tserver.sh",
-                          "https://raw.githubusercontent.com/YugaByte/utilities/master/azure_scripts/create_universe.sh"
+                          "https://raw.githubusercontent.com/YugaByte/utilities/master/common_scripts/create_universe.sh"
                         ]
                       },
                       "protectedSettings": {
-                        "commandToExecute": "[concat(' bash install_software.sh ',parameters('YBVersion'), ' ',parameters('SshUser'),' && mv start_* /home/',parameters('SshUser'), ' && bash create_universe.sh Azure ', resourceGroup().location, ' 3 ',reference(concat(parameters('ClusterName'),'networkInterface1'),'2016-09-01').ipConfigurations[0].properties.privateIPAddress,' ',reference(concat(parameters('ClusterName'),'networkInterface2'),'2016-09-01').ipConfigurations[0].properties.privateIPAddress,' ',reference(concat(parameters('ClusterName'),'networkInterface3'),'2016-09-01').ipConfigurations[0].properties.privateIPAddress, ' ', add(copyIndex('vm'),1),' ',parameters('SshUser'))]"           
+                        "commandToExecute": "[concat('mv *.sh /home/',parameters('SshUser'),' && chmod 0755 /home/',parameters('SshUser'),'/*.sh && chown ',parameters('SshUser'),':',parameters('SshUser'),' /home/',parameters('SshUser'),'/*.sh && bash -c \"sudo -u ',parameters('SshUser'),' /home/',parameters('SshUser'),'/install_software.sh ',parameters('YBVersion'),'\"  && bash -c \"sudo -u ',parameters('SshUser'),' /home/',parameters('SshUser'),'/create_universe.sh Azure ', resourceGroup().location, ' 3 ',variables('singleQuote'),reference(concat(parameters('ClusterName'),'networkInterface1'),'2016-09-01').ipConfigurations[0].properties.privateIPAddress,' ',reference(concat(parameters('ClusterName'),'networkInterface2'),'2016-09-01').ipConfigurations[0].properties.privateIPAddress,' ',reference(concat(parameters('ClusterName'),'networkInterface3'),'2016-09-01').ipConfigurations[0].properties.privateIPAddress,variables('singleQuote'),' ',add(copyIndex('vm'),1),' ',parameters('SshUser'),'\"')]"           
                       }
                     }
                 }


### PR DESCRIPTION
- Issues fixed -
1. Previously yugabyte services are running by the root user, now they're running with respective SSH User which we pass with azure deployment command.
2. Replaced dedicated deployment scripts path to utilities repo' common scripts.
3. The "ulimits" aren't properly set as per yugabyte documentation. After the fix, they're working as we want.

- Modifications -
1. Added rpc_bind_addresses option in master.conf and tserver.conf.

The below-mentioned necessary conditions are tested with 3 nodes (3 masters) -
   - crontab entries should be set to the user.
   - ulimits configurations should be set for the user and running the yugabyte processes.
   - configuration files should have rpc_bind_addresses option with correct IP.
   - UI should work properly.